### PR TITLE
EDIT: Added custom parameter to ensure Google Popup even when only on…

### DIFF
--- a/client/src/components/OAuth.jsx
+++ b/client/src/components/OAuth.jsx
@@ -10,6 +10,7 @@ export default function OAuth() {
   const handleGoogleClick = async () => {
     try {
       const provider = new GoogleAuthProvider();
+      provider.setCustomParameters({ prompt: 'select_account' });
       const auth = getAuth(app);
 
       const result = await signInWithPopup(auth, provider);


### PR DESCRIPTION
This custom parameter enables Google Auth to always popup when the button is clicked even when only one user is signed in. It allows the user select the account on the pop up before creating a new user or signing in an existing user.

Without this custom parameter set, when a user clicks the button, it would sign in automatically without the popup showing up prior. This may cause the user to assume it didn't work except a redirect is manually set (such as the auto redirect to the profile page within this application).